### PR TITLE
remove string quotes from workspace props

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -28,5 +28,5 @@ The `Workspace` will automatically take full width and height of its parent. So 
 Optionally you can hide UI to add/remove/duplicate pages.
 
 ```html
-<Workspace store="{store}" pageControlsEnabled="{false}" />
+<Workspace store={store} pageControlsEnabled={false} />
 ```


### PR DESCRIPTION
I think these properties need to be passed as plain types not string.